### PR TITLE
Add negative test for test_svm size check

### DIFF
--- a/test_conformance/SVM/CMakeLists.txt
+++ b/test_conformance/SVM/CMakeLists.txt
@@ -4,6 +4,7 @@ set(MODULE_NAME SVM)
 set(${MODULE_NAME}_SOURCES
     main.cpp
     test_allocate_shared_buffer.cpp
+    test_allocate_shared_buffer_negative.cpp
     test_byte_granularity.cpp
     test_cross_buffer_pointers.cpp
     test_enqueue_api.cpp

--- a/test_conformance/SVM/common.h
+++ b/test_conformance/SVM/common.h
@@ -92,6 +92,10 @@ extern int    test_svm_shared_address_space_fine_grain(cl_device_id deviceID, cl
 extern int    test_svm_cross_buffer_pointers_coarse_grain(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int    test_svm_pointer_passing(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int    test_svm_allocate_shared_buffer(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
+extern int test_svm_allocate_shared_buffer_negative(cl_device_id deviceID,
+                                                    cl_context context,
+                                                    cl_command_queue queue,
+                                                    int num_elements);
 extern int    test_svm_shared_sub_buffers(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int    test_svm_enqueue_api(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);
 extern int    test_svm_migrate(cl_device_id deviceID, cl_context context, cl_command_queue queue, int num_elements);

--- a/test_conformance/SVM/main.cpp
+++ b/test_conformance/SVM/main.cpp
@@ -261,20 +261,21 @@ cl_int create_cl_objects(cl_device_id device_from_harness, const char** ppCodeSt
 }
 
 test_definition test_list[] = {
-    ADD_TEST( svm_byte_granularity),
-    ADD_TEST( svm_set_kernel_exec_info_svm_ptrs ),
-    ADD_TEST( svm_fine_grain_memory_consistency ),
-    ADD_TEST( svm_fine_grain_sync_buffers ),
-    ADD_TEST( svm_shared_address_space_fine_grain ),
-    ADD_TEST( svm_shared_sub_buffers ),
-    ADD_TEST( svm_shared_address_space_fine_grain_buffers ),
-    ADD_TEST( svm_allocate_shared_buffer ),
-    ADD_TEST( svm_shared_address_space_coarse_grain_old_api ),
-    ADD_TEST( svm_shared_address_space_coarse_grain_new_api ),
-    ADD_TEST( svm_cross_buffer_pointers_coarse_grain ),
-    ADD_TEST( svm_pointer_passing ),
-    ADD_TEST( svm_enqueue_api ),
-    ADD_TEST_VERSION( svm_migrate, Version(2, 1)),
+    ADD_TEST(svm_byte_granularity),
+    ADD_TEST(svm_set_kernel_exec_info_svm_ptrs),
+    ADD_TEST(svm_fine_grain_memory_consistency),
+    ADD_TEST(svm_fine_grain_sync_buffers),
+    ADD_TEST(svm_shared_address_space_fine_grain),
+    ADD_TEST(svm_shared_sub_buffers),
+    ADD_TEST(svm_shared_address_space_fine_grain_buffers),
+    ADD_TEST(svm_allocate_shared_buffer),
+    ADD_TEST(svm_allocate_shared_buffer_negative),
+    ADD_TEST(svm_shared_address_space_coarse_grain_old_api),
+    ADD_TEST(svm_shared_address_space_coarse_grain_new_api),
+    ADD_TEST(svm_cross_buffer_pointers_coarse_grain),
+    ADD_TEST(svm_pointer_passing),
+    ADD_TEST(svm_enqueue_api),
+    ADD_TEST_VERSION(svm_migrate, Version(2, 1)),
 };
 
 const int test_num = ARRAY_SIZE( test_list );

--- a/test_conformance/SVM/test_allocate_shared_buffer_negative.cpp
+++ b/test_conformance/SVM/test_allocate_shared_buffer_negative.cpp
@@ -1,0 +1,102 @@
+//
+// Copyright (c) 2017 The Khronos Group Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+#include "common.h"
+
+const cl_mem_flags svm_flag_set[] = {
+    CL_MEM_READ_WRITE,
+    CL_MEM_WRITE_ONLY,
+    CL_MEM_READ_ONLY,
+    CL_MEM_READ_WRITE | CL_MEM_SVM_FINE_GRAIN_BUFFER,
+    CL_MEM_WRITE_ONLY | CL_MEM_SVM_FINE_GRAIN_BUFFER,
+    CL_MEM_READ_ONLY | CL_MEM_SVM_FINE_GRAIN_BUFFER,
+    CL_MEM_READ_WRITE | CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_SVM_ATOMICS,
+    CL_MEM_WRITE_ONLY | CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_SVM_ATOMICS,
+    CL_MEM_READ_ONLY | CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_SVM_ATOMICS,
+    0
+};
+const char* svm_flag_set_names[] = {
+    "CL_MEM_READ_WRITE",
+    "CL_MEM_WRITE_ONLY",
+    "CL_MEM_READ_ONLY",
+    "CL_MEM_READ_WRITE | CL_MEM_SVM_FINE_GRAIN_BUFFER",
+    "CL_MEM_WRITE_ONLY | CL_MEM_SVM_FINE_GRAIN_BUFFER",
+    "CL_MEM_READ_ONLY | CL_MEM_SVM_FINE_GRAIN_BUFFER",
+    "CL_MEM_READ_WRITE | CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_SVM_ATOMICS",
+    "CL_MEM_WRITE_ONLY | CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_SVM_ATOMICS",
+    "CL_MEM_READ_ONLY | CL_MEM_SVM_FINE_GRAIN_BUFFER | CL_MEM_SVM_ATOMICS",
+    "0"
+};
+
+
+int test_svm_allocate_shared_buffer_negative(cl_device_id deviceID,
+                                             cl_context context2,
+                                             cl_command_queue queue,
+                                             int num_elements)
+{
+    clContextWrapper context = NULL;
+    clProgramWrapper program = NULL;
+    cl_uint num_devices = 0;
+    cl_int err = CL_SUCCESS;
+    clCommandQueueWrapper queues[MAXQ];
+
+    cl_device_svm_capabilities caps;
+    err = clGetDeviceInfo(deviceID, CL_DEVICE_SVM_CAPABILITIES,
+                          sizeof(cl_device_svm_capabilities), &caps, NULL);
+    test_error(err, "clGetDeviceInfo failed for CL_DEVICE_SVM_CAPABILITIES");
+
+    // under construction...
+    err = create_cl_objects(deviceID, NULL, &context, &program, &queues[0],
+                            &num_devices, CL_DEVICE_SVM_COARSE_GRAIN_BUFFER);
+    if (err) return -1;
+
+    size_t size = 1024;
+
+    // iteration over flag combos
+    int num_flags = sizeof(svm_flag_set) / sizeof(cl_mem_flags);
+    for (int i = 0; i < num_flags; i++)
+    {
+        if (((svm_flag_set[i] & CL_MEM_SVM_FINE_GRAIN_BUFFER) != 0
+             && (caps & CL_DEVICE_SVM_FINE_GRAIN_BUFFER) == 0)
+            || ((svm_flag_set[i] & CL_MEM_SVM_ATOMICS) != 0
+                && (caps & CL_DEVICE_SVM_ATOMICS) == 0))
+        {
+            log_info("Skipping clSVMalloc with flags: %s\n",
+                     svm_flag_set_names[i]);
+            continue;
+        }
+
+        log_info("Testing clSVMalloc with flags: %s\n", svm_flag_set_names[i]);
+        cl_char* pBufData1 =
+            (cl_char*)clSVMAlloc(context, svm_flag_set[i], size, 0);
+        if (pBufData1 == NULL)
+        {
+            log_error("SVMalloc returned NULL");
+            return -1;
+        }
+
+        {
+            clMemWrapper buf1 = clCreateBuffer(context, CL_MEM_USE_HOST_PTR,
+                                               2 * size, pBufData1, &err);
+            test_failure_error(err, CL_INVALID_BUFFER_SIZE,
+                               "clCreateBuffer did not return expected error"
+                               "CL_INVALID_BUFFER_SIZE");
+        }
+
+        clSVMFree(context, pBufData1);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Isuue #875 clarified that CL_INVALID_BUFFER_SIZE should be returned if clCreateBuffer is passed a pointer returned by clSVMAlloc as its host_ptr and the size of the buffer exceeds the size of the SVM allocation.

Add a new negative test to ensure CL_INVALID_BUFFER_SIZE is returned when the size of buffer exceeds the size of the SVM allocation.

Fixes #1701